### PR TITLE
Add loaded metrics cache, split metrics store into own interface

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,9 +1,10 @@
 riffl
 * Sink task allocation should allow responding to traffic and reduce/expand number of tasks per Sink
-* Task assigner metrics should calculate globally and be the same for every Sink task
-  Task assigner metrics should be allowed to persist externally
+[DONE] * Task assigner metrics should calculate globally and be the same for every Sink task
+[DONE]   Task assigner metrics should be allowed to persist externally
 * Configuration should allow for Sink query to be optional loading data as-is from the Source
-* Bump Flink version to 1.15
+[DONE] * Bump Flink version to 1.15
+* Metric local store should be limited in size e.g. frequent item sketch
 
 riffl-deployemnt
 * Add Docker build

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ jackson = "2.13.3"
 hadoop-local-runner = "2.10.2" # riffl-local
 commons-text = "1.10.0"
 spotless = "6.11.0"
+caffeine = "3.1.2"
 
 [libraries]
 flink-streaming-java = { module = "org.apache.flink:flink-streaming-java", version.ref = "flink" }
@@ -36,6 +37,7 @@ typesafe-config = { module = "com.typesafe:config", version.ref = "typesafe-conf
 jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }
 jackson-dataformat-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }
 commons-text = { module = "org.apache.commons:commons-text", version.ref = "commons-text" }
+caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }
 
 [bundles]
 flink-core = [

--- a/riffl-core/build.gradle
+++ b/riffl-core/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     implementation libs.jackson.core
     implementation libs.jackson.dataformat.yaml
     implementation libs.commons.text
+    implementation libs.caffeine
 
     runtimeOnly libs.bundles.log4j
     testImplementation libs.bundles.tests

--- a/riffl-core/src/main/java/io/riffl/sink/SinkUtils.java
+++ b/riffl-core/src/main/java/io/riffl/sink/SinkUtils.java
@@ -3,7 +3,6 @@ package io.riffl.sink;
 import io.riffl.config.Sink;
 import io.riffl.sink.metrics.Metric;
 import java.text.MessageFormat;
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.util.OutputTag;
 
@@ -13,10 +12,10 @@ public class SinkUtils {
     return new OutputTag<>(MessageFormat.format("{0}-{1}", sink.getTable(), "metrics-sink")) {};
   }
 
-  public static Path getMetricsPath(Path base, Sink sink, JobID jobID) {
+  public static Path getMetricsPath(Path base, Sink sink) {
     return new Path(
         MessageFormat.format(
-            "{0}/{1}/metrics-{2}-", base.toString(), jobID.toString(), sink.getTable()));
+            "{0}/{1}/metrics-{2}-", base.toString(), "riffl-metrics-store", sink.getTable()));
   }
 
   public static String getOperatorName(Sink sink, String name) {

--- a/riffl-core/src/main/java/io/riffl/sink/metrics/DefaultMetricsProcessor.java
+++ b/riffl-core/src/main/java/io/riffl/sink/metrics/DefaultMetricsProcessor.java
@@ -3,12 +3,8 @@ package io.riffl.sink.metrics;
 import io.riffl.config.ConfigUtils;
 import io.riffl.config.Sink;
 import io.riffl.sink.row.RowKey;
-import java.io.IOException;
-import java.io.ObjectInputStream;
 import java.util.HashMap;
 import java.util.function.Consumer;
-import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.core.fs.Path;
 import org.apache.flink.types.Row;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,13 +13,12 @@ public class DefaultMetricsProcessor implements MetricsProcessor {
 
   private static final Logger logger = LoggerFactory.getLogger(DefaultMetricsProcessor.class);
   static final String PROPERTIES_METRIC_TYPE = "metricType";
+  static final int DEFAULT_METRICS_NUM_RETAINED = 5;
 
   private final MetricType metricType;
 
-  // should be fixed in size
-  private final HashMap<RowKey, Long> store = new HashMap<>();
-  private final Path metricsPath;
-  private final Sink sink;
+  // should be a fixed in size sketch
+  private final HashMap<RowKey, Long> metricValueStore = new HashMap<>();
 
   private boolean hasMetricsToConsume = false;
 
@@ -32,20 +27,21 @@ public class DefaultMetricsProcessor implements MetricsProcessor {
     BYTES
   }
 
-  public DefaultMetricsProcessor(Sink sink, Path metricsPath) {
-    this.sink = sink;
-    this.metricsPath = metricsPath;
+  final MetricsStore externalMetricsStore;
+
+  public DefaultMetricsProcessor(Sink sink, MetricsStore metricsStore) {
     this.metricType =
         ConfigUtils.enumProperty(
             sink.getDistribution().getProperties().get(PROPERTIES_METRIC_TYPE),
             MetricType.class,
             MetricType.COUNT);
+    this.externalMetricsStore = metricsStore;
   }
 
   @Override
   public void addMetric(RowKey key, Row row) {
     var value = metricType == MetricType.COUNT ? 1L : row.toString().getBytes().length;
-    store.merge(key, value, Long::sum);
+    metricValueStore.merge(key, value, Long::sum);
   }
 
   @Override
@@ -60,50 +56,18 @@ public class DefaultMetricsProcessor implements MetricsProcessor {
 
   @Override
   public void consumeMetrics(Consumer<Metric> consumer) {
-    store.forEach((key, value) -> consumer.accept(new Metric(key, value)));
-    store.clear();
+    metricValueStore.forEach((key, value) -> consumer.accept(new Metric(key, value)));
+    metricValueStore.clear();
     this.hasMetricsToConsume = false;
   }
 
-  // Todo: add caching layer
   @Override
   public Metrics getMetrics(long checkpointId) {
-    Metrics metrics;
     if (checkpointId > 1) {
-      var path = new Path(metricsPath.toString() + (checkpointId - 1));
-      var removePath = new Path(metricsPath.toString() + (checkpointId - 2));
-
-      try {
-        var fs = FileSystem.getUnguardedFileSystem(path.toUri());
-
-        try (var file = fs.open(path)) {
-          ObjectInputStream objectInput = new ObjectInputStream(file);
-
-          metrics = (Metrics) objectInput.readObject();
-          logger.info(
-              "Loaded metrics for checkpoint: {}, sink {}: {}",
-              checkpointId - 1,
-              sink.getTable(),
-              metrics);
-          if (fs.exists(removePath)) {
-            fs.delete(removePath, false);
-            logger.info(
-                "Deleted metrics for checkpoint: {}, sink {}, path {}",
-                checkpointId - 2,
-                sink.getTable(),
-                removePath);
-          }
-          return metrics;
-        } catch (IOException | ClassNotFoundException e) {
-          throw new RuntimeException(e);
-        }
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
+      externalMetricsStore.removeMetrics(checkpointId - DEFAULT_METRICS_NUM_RETAINED);
+      return externalMetricsStore.loadMetrics(checkpointId - 1);
     } else {
-      metrics = new Metrics();
+      return new Metrics();
     }
-
-    return metrics;
   }
 }

--- a/riffl-core/src/main/java/io/riffl/sink/metrics/FilesystemMetricsStore.java
+++ b/riffl-core/src/main/java/io/riffl/sink/metrics/FilesystemMetricsStore.java
@@ -1,0 +1,80 @@
+package io.riffl.sink.metrics;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.FileSystem.WriteMode;
+import org.apache.flink.core.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FilesystemMetricsStore implements MetricsStore, Serializable {
+
+  private static final Logger logger = LoggerFactory.getLogger(FilesystemMetricsStore.class);
+  final Path basePath;
+
+  protected static final LoadingCache<Path, Metrics> cache =
+      Caffeine.newBuilder().build(FilesystemMetricsStore::loadMetricsFromFile);
+
+  protected static Metrics loadMetricsFromFile(Path path) {
+    try {
+      var fs = FileSystem.getUnguardedFileSystem(path.toUri());
+      try (var file = fs.open(path)) {
+        ObjectInputStream objectInput = new ObjectInputStream(file);
+        var metrics = (Metrics) objectInput.readObject();
+        logger.info("Loaded metrics for path: {},  {}", path, metrics);
+        return metrics;
+      } catch (IOException | ClassNotFoundException e) {
+        throw new IOException(e);
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public FilesystemMetricsStore(Path basePath) {
+    this.basePath = basePath;
+  }
+
+  @Override
+  public Metrics loadMetrics(long checkpointId) {
+    return cache.get(new Path(basePath.toString() + checkpointId));
+  }
+
+  @Override
+  public void removeMetrics(long checkpointId) {
+    var path = new Path(basePath.toString() + checkpointId);
+    try {
+      var fs = FileSystem.getUnguardedFileSystem(path.toUri());
+      if (fs.exists(path)) {
+        fs.delete(path, false);
+
+        cache.invalidate(path);
+        logger.info("Deleted metrics for checkpoint: {}, path {}", checkpointId, path);
+      }
+    } catch (IOException e) {
+      logger.error("Failed to delete metrics for checkpoint: {}, path {}", checkpointId, path);
+    }
+  }
+
+  @Override
+  public void writeMetrics(long checkpointId, Metrics metrics) {
+    var path = new Path(basePath.toString() + checkpointId);
+    try {
+      var fs = FileSystem.getUnguardedFileSystem(path.toUri());
+      try (var file = fs.create(path, WriteMode.OVERWRITE)) {
+        file.write(metrics.toByteArray());
+      }
+      logger.info(
+          "Persisted metrics for checkpoint: {}, path {}: {}",
+          checkpointId,
+          path,
+          metrics.entrySet());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/riffl-core/src/main/java/io/riffl/sink/metrics/Metrics.java
+++ b/riffl-core/src/main/java/io/riffl/sink/metrics/Metrics.java
@@ -8,6 +8,7 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
 public class Metrics implements Serializable {
@@ -35,6 +36,23 @@ public class Metrics implements Serializable {
 
   public Set<Entry<RowKey, Long>> entrySet() {
     return store.entrySet();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Metrics metrics = (Metrics) o;
+    return store.equals(metrics.store);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(store);
   }
 
   @Override

--- a/riffl-core/src/main/java/io/riffl/sink/metrics/MetricsSink.java
+++ b/riffl-core/src/main/java/io/riffl/sink/metrics/MetricsSink.java
@@ -1,11 +1,5 @@
 package io.riffl.sink.metrics;
 
-import io.riffl.config.Sink;
-import io.riffl.sink.SinkUtils;
-import java.io.IOException;
-import org.apache.flink.core.fs.FileSystem;
-import org.apache.flink.core.fs.FileSystem.WriteMode;
-import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
@@ -16,13 +10,12 @@ import org.slf4j.LoggerFactory;
 public class MetricsSink extends RichSinkFunction<Metric> implements CheckpointedFunction {
 
   private static final Logger logger = LoggerFactory.getLogger(MetricsSink.class);
-  private final Path metricsPathBase;
-  private final Metrics metrics;
-  private final Sink sink;
 
-  public MetricsSink(Sink sink, Path metricsPathBase) {
-    this.sink = sink;
-    this.metricsPathBase = metricsPathBase;
+  private final Metrics metrics;
+  private final MetricsStore metricsStore;
+
+  public MetricsSink(MetricsStore metricsStore) {
+    this.metricsStore = metricsStore;
     this.metrics = new Metrics();
   }
 
@@ -33,25 +26,7 @@ public class MetricsSink extends RichSinkFunction<Metric> implements Checkpointe
 
   @Override
   public void snapshotState(FunctionSnapshotContext context) {
-    try {
-      var checkpointId = context.getCheckpointId();
-      var metricsPath =
-          new Path(
-              SinkUtils.getMetricsPath(metricsPathBase, sink, getRuntimeContext().getJobId())
-                      .toString()
-                  + checkpointId);
-      FileSystem fs = FileSystem.getUnguardedFileSystem(metricsPath.toUri());
-      try (var file = fs.create(metricsPath, WriteMode.OVERWRITE)) {
-        file.write(metrics.toByteArray());
-      }
-      logger.info(
-          "Persisted metrics for checkpoint: {}, sink {}: {}",
-          checkpointId,
-          sink.getTable(),
-          metrics.entrySet());
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    metricsStore.writeMetrics(context.getCheckpointId(), metrics);
     metrics.clear();
   }
 

--- a/riffl-core/src/main/java/io/riffl/sink/metrics/MetricsStore.java
+++ b/riffl-core/src/main/java/io/riffl/sink/metrics/MetricsStore.java
@@ -1,0 +1,10 @@
+package io.riffl.sink.metrics;
+
+public interface MetricsStore {
+
+  Metrics loadMetrics(long checkpointId);
+
+  void removeMetrics(long checkpointId);
+
+  void writeMetrics(long checkpointId, Metrics metrics);
+}

--- a/riffl-core/src/test/java/io/riffl/sink/metrics/FilesystemMetricsStoreTests.java
+++ b/riffl-core/src/test/java/io/riffl/sink/metrics/FilesystemMetricsStoreTests.java
@@ -1,0 +1,101 @@
+package io.riffl.sink.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.riffl.sink.row.RowKey;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class FilesystemMetricsStoreTests {
+
+  private Row getTestRow() {
+    Row row = Row.withNames(RowKind.INSERT);
+    row.setField("aaa", "aaaData");
+    row.setField("bbb", 0.1d);
+    row.setField("ccc", null);
+
+    return row;
+  }
+
+  @Test
+  void metricsShouldBeLoadedFromFile() {
+    var metricsStore =
+        new FilesystemMetricsStore(new Path("./src/test/resources/metrics-table_name-"));
+
+    var metrics = metricsStore.loadMetrics(2);
+    var result =
+        metrics.entrySet().stream().collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+    var key1 = new RowKey(getTestRow(), List.of("aaa", "bbb", "ccc"));
+    var key2 = new RowKey(getTestRow(), List.of("aaa", "bbb"));
+
+    assertEquals(2, result.size());
+    assertEquals(1L, result.get(key1));
+    assertEquals(10000L, result.get(key2));
+  }
+
+  @Test
+  void metricsShouldBeWrittenAndOverwrittenIntoFile(@TempDir java.nio.file.Path tempDir) {
+    var tempPrefix = tempDir + "/metrics-";
+    var metricsStore = new FilesystemMetricsStore(new Path(tempPrefix));
+
+    var key1 = new RowKey(getTestRow(), List.of("aaa", "bbb", "ccc"));
+    var key2 = new RowKey(getTestRow(), List.of("aaa", "bbb"));
+    var metrics = new Metrics();
+    metrics.add(key1, 1L);
+    metrics.add(key2, 10000L);
+
+    // write first time
+    metricsStore.writeMetrics(2, metrics);
+    var outputFile = tempPrefix + 2;
+    assertTrue(Files.exists(java.nio.file.Path.of(outputFile)));
+
+    // write second time
+    metricsStore.writeMetrics(2, metrics);
+
+    Map<RowKey, Long> result;
+    try (FileInputStream fileInputStream = new FileInputStream(outputFile);
+        ObjectInputStream objectInput = new ObjectInputStream(fileInputStream)) {
+      var loadedMetrics = (Metrics) objectInput.readObject();
+      result =
+          loadedMetrics.entrySet().stream()
+              .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+    } catch (IOException | ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+    assertEquals(2, result.size());
+    assertEquals(1L, result.get(key1));
+    assertEquals(10000L, result.get(key2));
+  }
+
+  @Test
+  void metricsShouldBeRemoved(@TempDir java.nio.file.Path tempDir) {
+    var tempPrefix = tempDir + "/metrics-";
+    var metricsStore = new FilesystemMetricsStore(new Path(tempPrefix));
+
+    var key1 = new RowKey(getTestRow(), List.of("aaa", "bbb", "ccc"));
+    var key2 = new RowKey(getTestRow(), List.of("aaa", "bbb"));
+    var metrics = new Metrics();
+    metrics.add(key1, 1L);
+    metrics.add(key2, 10000L);
+
+    metricsStore.writeMetrics(2, metrics);
+    var outputFile = tempPrefix + 2;
+    assertTrue(Files.exists(java.nio.file.Path.of(outputFile)));
+    metricsStore.removeMetrics(2);
+    assertFalse(Files.exists(java.nio.file.Path.of(outputFile)));
+  }
+}

--- a/riffl-core/src/test/java/io/riffl/sink/metrics/MetricsTests.java
+++ b/riffl-core/src/test/java/io/riffl/sink/metrics/MetricsTests.java
@@ -1,0 +1,32 @@
+package io.riffl.sink.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.riffl.sink.row.RowKey;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.util.List;
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+import org.junit.jupiter.api.Test;
+
+public class MetricsTests {
+
+  @Test
+  void metricsShouldReturnContentAsByteArray() throws IOException, ClassNotFoundException {
+    var metrics = new Metrics();
+    Row row = Row.withNames(RowKind.INSERT);
+    row.setField("aaa", "aaaData");
+    row.setField("bbb", 0.1d);
+    row.setField("ccc", null);
+    var key1 = new RowKey(row, List.of("aaa", "bbb", "ccc"));
+    metrics.add(key1, 10000L);
+
+    try (var byteArrayInput = new ByteArrayInputStream(metrics.toByteArray());
+        var objectInput = new ObjectInputStream(byteArrayInput)) {
+      var metricsObject = (Metrics) objectInput.readObject();
+      assertEquals(metrics, metricsObject);
+    }
+  }
+}


### PR DESCRIPTION
* Cache externally loaded metrics per task manager.
* Split metrics store logic into own interface and implementation.